### PR TITLE
Fix time entry timezone

### DIFF
--- a/src/td/cli/task.py
+++ b/src/td/cli/task.py
@@ -334,9 +334,9 @@ def toggle_task(task_id: str):
             task = update_task_in_db(session, task_id, {"status": task_status})
             _time_entry = get_active_time_entry_for_task_from_db(session, task_id)
             if task.status == 1 and _time_entry:
-                from datetime import datetime
+                from datetime import datetime, timezone
 
-                end_time = datetime.now()
+                end_time = datetime.now(timezone.utc)
                 time_entry = TimeEntryUpdate(
                     task_id=task.id,
                     end_time=end_time,

--- a/src/td/crud/time_entry.py
+++ b/src/td/crud/time_entry.py
@@ -119,8 +119,8 @@ def calculate_total_time_for_task(db: Session, task_id: int) -> float:
     for entry in entries:
         start_time = entry.start_time
         end_time = (
-            entry.end_time or datetime.now()
-        )  # Use current time if entry is active
+            entry.end_time or datetime.now(timezone.utc)
+        )  # Use current UTC time if entry is active
         duration = end_time - start_time
         total_duration_seconds += duration.total_seconds()
 

--- a/tests/td/unit/test_time_entry.py
+++ b/tests/td/unit/test_time_entry.py
@@ -1,0 +1,25 @@
+import pytest
+from sqlmodel import SQLModel, Session, create_engine
+from datetime import datetime, timedelta, timezone
+
+from td.models import Task, TaskCreate
+from td.models import TimeEntryCreate
+from td.crud.task import create_task_in_db
+from td.crud.time_entry import create_time_entry_in_db, calculate_total_time_for_task
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def test_calculate_total_time_active_entry(session: Session):
+    task = create_task_in_db(session, TaskCreate(title="task"))
+    start = datetime.now(timezone.utc) - timedelta(hours=1)
+    time_entry = TimeEntryCreate(task_id=task.id, start_time=start)
+    create_time_entry_in_db(session, time_entry)
+    total = calculate_total_time_for_task(session, task.id)
+    assert total > 3590
+    assert total <= 3605


### PR DESCRIPTION
## Summary
- ensure active time entries use UTC time
- stop timers with timezone aware datetimes
- add a regression test for calculating total time

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68412915684883328289ec17e9218910